### PR TITLE
main: load the webpack-dev-server page when production is not set

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,8 +8,14 @@ function createWindow () {
   })
   win.maximize()
   win.show()
-  // and load the index.html of the app.
-  win.loadFile("dist/index.html")
+  if (process.env.PRODUCTION) {
+    // and load the index.html of the app.
+    win.loadFile("dist/index.html")
+  } else {
+    // webpack-dev-server defaults to port 8080
+    const port = process.env.PORT || 8080;
+    win.loadURL(`http://localhost:${port}`)
+  }
 }
 
 app.on("ready", createWindow)


### PR DESCRIPTION
This makes it easier to experiment faster with the code. When webpack
rebuilds the electron page should now refresh.

Thanks for making this project available, will use it to build some nice desktop tools 😄 